### PR TITLE
argv-parser-rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,15 @@ git-stacked-rebase <branch>
     2. but will not apply the changes to partial branches until --apply is used.
 
 
-git-stacked-rebase <branch> [-a|--apply]
+git-stacked-rebase [-a|--apply]
 
-    1. will apply the changes to partial branches,
-    2. but will not push any partial branches to a remote until --push is used.
+    3. will apply the changes to partial branches,
+    4. but will not push any partial branches to a remote until --push is used.
 
 
-git-stacked-rebase <branch> [-p|--push -f|--force]
+git-stacked-rebase [-p|--push -f|--force]
 
-    1. will push partial branches with --force (and extra safety).
+    5. will push partial branches with --force (and extra safety).
 
 
 

--- a/argparse/argparse.spec.ts
+++ b/argparse/argparse.spec.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env ts-node-dev
+
+import assert from "assert";
+
+import { NonPositional, NonPositionalWithValue, eatNonPositionals, eatNonPositionalsWithValues } from "./argparse";
+
+export function argparse_TC() {
+	eatNonPositionals_singleArg();
+	eatNonPositionals_multipleArgs();
+
+	eatNonPositionalsWithValues_singleArg();
+	eatNonPositionalsWithValues_multipleArgs();
+}
+
+function eatNonPositionals_singleArg() {
+	const argv = ["origin/master", "--autosquash", "foo", "bar"];
+	const targetArgs = ["--autosquash", "--no-autosquash"];
+	const expected: NonPositional[] = [{ argName: "--autosquash", origIdx: 1 }];
+	const expectedLeftoverArgv = ["origin/master", "foo", "bar"];
+
+	const parsed = eatNonPositionals(targetArgs, argv);
+
+	assert.deepStrictEqual(parsed, expected);
+	assert.deepStrictEqual(argv, expectedLeftoverArgv);
+}
+function eatNonPositionals_multipleArgs() {
+	const argv = ["origin/master", "--autosquash", "foo", "bar", "--no-autosquash", "baz"];
+	const targetArgs = ["--autosquash", "--no-autosquash"];
+	const expected: NonPositional[] = [
+		{ argName: "--autosquash", origIdx: 1 },
+		{ argName: "--no-autosquash", origIdx: 4 },
+	];
+	const expectedLeftoverArgv = ["origin/master", "foo", "bar", "baz"];
+
+	const parsed = eatNonPositionals(targetArgs, argv);
+
+	assert.deepStrictEqual(parsed, expected);
+	assert.deepStrictEqual(argv, expectedLeftoverArgv);
+}
+
+function eatNonPositionalsWithValues_singleArg() {
+	const argv = ["origin/master", "--git-dir", "~/.dotfiles", "foo", "bar"];
+	const targetArgs = ["--git-dir", "--gd"];
+	const expected: NonPositionalWithValue[] = [{ argName: "--git-dir", origIdx: 1, argVal: "~/.dotfiles" }];
+	const expectedLeftoverArgv = ["origin/master", "foo", "bar"];
+
+	const parsed = eatNonPositionalsWithValues(targetArgs, argv);
+
+	assert.deepStrictEqual(parsed, expected);
+	assert.deepStrictEqual(argv, expectedLeftoverArgv);
+}
+function eatNonPositionalsWithValues_multipleArgs() {
+	const argv = ["origin/master", "--git-dir", "~/.dotfiles", "foo", "bar", "--misc", "miscVal", "unrelatedVal"];
+	const targetArgs = ["--git-dir", "--gd", "--misc"];
+	const expected: NonPositionalWithValue[] = [
+		{ argName: "--git-dir", origIdx: 1, argVal: "~/.dotfiles" },
+		{ argName: "--misc", origIdx: 5, argVal: "miscVal" },
+	];
+	const expectedLeftoverArgv = ["origin/master", "foo", "bar", "unrelatedVal"];
+
+	const parsed = eatNonPositionalsWithValues(targetArgs, argv);
+
+	assert.deepStrictEqual(parsed, expected);
+	assert.deepStrictEqual(argv, expectedLeftoverArgv);
+}
+
+if (!module.parent) {
+	argparse_TC();
+}

--- a/argparse/argparse.ts
+++ b/argparse/argparse.ts
@@ -1,0 +1,140 @@
+import assert from "assert";
+
+export type Maybe<T> = T | undefined;
+
+export type Argv = string[];
+export type MaybeArg = Maybe<string>;
+
+/**
+ * parses the argv.
+ * mutates the `argv` array.
+ */
+export function createArgParse(argv: Argv) {
+	const getArgv = (): Argv => argv;
+	const peakNextArg = (): MaybeArg => argv[0];
+	const eatNextArg = (): MaybeArg => argv.shift();
+	const hasMoreArgs = (): boolean => argv.length > 0;
+
+	return {
+		getArgv,
+		peakNextArg,
+		eatNextArg,
+		hasMoreArgs,
+		eatNonPositionals: (argNames: string[]) => eatNonPositionals(argNames, argv),
+		eatNonPositionalsWithValues: (argNames: string[]) => eatNonPositionalsWithValues(argNames, argv),
+	};
+}
+
+export type NonPositional = {
+	origIdx: number;
+	argName: string;
+};
+
+export type NonPositionalWithValue = NonPositional & {
+	argVal: string;
+};
+
+export function eatNonPositionals(
+	argNames: string[],
+	argv: Argv,
+	{
+		howManyItemsToTakeWhenArgMatches = 1, //
+	} = {}
+): NonPositional[] {
+	const argMatches = (idx: number) => argNames.includes(argv[idx]);
+	let matchedArgIndexes: NonPositional["origIdx"][] = [];
+
+	for (let i = 0; i < argv.length; i++) {
+		if (argMatches(i)) {
+			for (let j = 0; j < howManyItemsToTakeWhenArgMatches; j++) {
+				matchedArgIndexes.push(i + j);
+			}
+		}
+	}
+
+	if (!matchedArgIndexes.length) {
+		return [];
+	}
+
+	const nonPositionalsWithValues: NonPositional[] = [];
+	for (const idx of matchedArgIndexes) {
+		nonPositionalsWithValues.push({
+			origIdx: idx,
+			argName: argv[idx],
+		});
+	}
+
+	const shouldRemoveArg = (idx: number) => matchedArgIndexes.includes(idx);
+	const argvIndexesToRemove: number[] = [];
+
+	for (let i = 0; i < argv.length; i++) {
+		if (shouldRemoveArg(i)) {
+			argvIndexesToRemove.push(i);
+		}
+	}
+
+	removeArrayValuesAtIndices(argv, argvIndexesToRemove);
+
+	return nonPositionalsWithValues;
+}
+
+export function eatNonPositionalsWithValues(argNames: string[], argv: Argv): NonPositionalWithValue[] {
+	const argsWithTheirValueAsNextItem: NonPositional[] = eatNonPositionals(argNames, argv, {
+		howManyItemsToTakeWhenArgMatches: 2,
+	});
+
+	assert.deepStrictEqual(argsWithTheirValueAsNextItem.length % 2, 0, `expected all arguments to have a value.`);
+
+	const properArgsWithValues: NonPositionalWithValue[] = [];
+	for (let i = 0; i < argsWithTheirValueAsNextItem.length; i += 2) {
+		const arg = argsWithTheirValueAsNextItem[i];
+		const val = argsWithTheirValueAsNextItem[i + 1];
+
+		properArgsWithValues.push({
+			origIdx: arg.origIdx,
+			argName: arg.argName,
+			argVal: val.argName,
+		});
+	}
+
+	return properArgsWithValues;
+}
+
+/**
+ * internal utils
+ */
+
+export function removeArrayValuesAtIndices<T>(arrayRef: T[], indexesToRemove: number[]): void {
+	/**
+	 * go in reverse.
+	 *
+	 * because if went from 0 to length,
+	 * removing an item from the array would adjust all other indices,
+	 * which creates a mess & needs extra handling.
+	 */
+	const indexesBigToSmall = [...indexesToRemove].sort((A, B) => B - A);
+
+	for (const idxToRemove of indexesBigToSmall) {
+		arrayRef.splice(idxToRemove, 1);
+	}
+
+	return;
+}
+
+/**
+ * common utilities for dealing w/ parsed values:
+ */
+
+export function maybe<T, S, N>(
+	x: T, //
+	Some: (x: T) => S,
+	None: (x?: never) => N
+) {
+	if (x instanceof Array) {
+		return x.length ? Some(x) : None();
+	}
+
+	return x !== undefined ? Some(x) : None();
+}
+
+export const last = <T>(xs: T[]): T => xs[xs.length - 1];

--- a/filenames.ts
+++ b/filenames.ts
@@ -10,6 +10,8 @@ export const filenames = {
 	gitRebaseTodo: "git-rebase-todo",
 	//
 	postStackedRebaseHook: "post-stacked-rebase",
+	//
+	initialBranch: "initial-branch",
 
 	/**
 	 * TODO extract others into here

--- a/parse-todo-of-stacked-rebase/parseNewGoodCommands.spec.ts
+++ b/parse-todo-of-stacked-rebase/parseNewGoodCommands.spec.ts
@@ -16,9 +16,9 @@ export async function parseNewGoodCommandsSpec(): Promise<void> {
 	await succeeds_to_apply_after_explicit_drop();
 
 	async function succeeds_to_apply_after_break_or_exec(): Promise<void> {
-		const { initialBranch, common, commitsInLatest } = await setupRepo();
+		const { common, commitsInLatest } = await setupRepo();
 
-		await gitStackedRebase(initialBranch, {
+		await gitStackedRebase({
 			...common,
 			[editor__internal]: ({ filePath }) => {
 				humanOpAppendLineAfterNthCommit("break", {
@@ -28,16 +28,16 @@ export async function parseNewGoodCommandsSpec(): Promise<void> {
 			},
 		});
 
-		await gitStackedRebase(initialBranch, {
+		await gitStackedRebase({
 			...common,
 			apply: true,
 		});
 	}
 
 	async function succeeds_to_apply_after_implicit_drop(): Promise<void> {
-		const { initialBranch, common, commitsInLatest } = await setupRepo();
+		const { common, commitsInLatest } = await setupRepo();
 
-		await gitStackedRebase(initialBranch, {
+		await gitStackedRebase({
 			...common,
 			[editor__internal]: ({ filePath }) => {
 				humanOpRemoveLineOfCommit({
@@ -47,16 +47,16 @@ export async function parseNewGoodCommandsSpec(): Promise<void> {
 			},
 		});
 
-		await gitStackedRebase(initialBranch, {
+		await gitStackedRebase({
 			...common,
 			apply: true,
 		});
 	}
 
 	async function succeeds_to_apply_after_explicit_drop(): Promise<void> {
-		const { initialBranch, common, commitsInLatest } = await setupRepo();
+		const { common, commitsInLatest } = await setupRepo();
 
-		await gitStackedRebase(initialBranch, {
+		await gitStackedRebase({
 			...common,
 			[editor__internal]: ({ filePath }) => {
 				humanOpChangeCommandOfNthCommitInto("drop", {
@@ -66,7 +66,7 @@ export async function parseNewGoodCommandsSpec(): Promise<void> {
 			},
 		});
 
-		await gitStackedRebase(initialBranch, {
+		await gitStackedRebase({
 			...common,
 			apply: true,
 		});

--- a/test/apply.spec.ts
+++ b/test/apply.spec.ts
@@ -20,7 +20,7 @@ export async function applyTC() {
  * create a scenario where an apply is needed, and disallow it - GSR should exit.
  */
 async function integration__git_stacked_rebase_exits_if_apply_was_needed_but_user_disallowed() {
-	const { initialBranch, common, commitsInLatest, config, repo } = await setupRepo();
+	const { common, commitsInLatest, config, repo } = await setupRepo();
 
 	/**
 	 * ensure autoApplyIfNeeded is disabled
@@ -30,7 +30,7 @@ async function integration__git_stacked_rebase_exits_if_apply_was_needed_but_use
 	/**
 	 * force modify history, so that an apply will be needed
 	 */
-	await gitStackedRebase(initialBranch, {
+	await gitStackedRebase({
 		...common,
 		[editor__internal]: ({ filePath }) => {
 			humanOpChangeCommandOfNthCommitInto("drop", {
@@ -57,7 +57,7 @@ async function integration__git_stacked_rebase_exits_if_apply_was_needed_but_use
 		 * and autoApplyIfNeeded is disabled,
 		 * we should get prompted to allow the apply.
 		 */
-		gitStackedRebase(initialBranch, {
+		gitStackedRebase({
 			...common,
 			...noEditor,
 			[askQuestion__internal]: (q, ...rest) => {

--- a/test/auto-checkout-remote-partial-branches.spec.ts
+++ b/test/auto-checkout-remote-partial-branches.spec.ts
@@ -40,7 +40,8 @@ async function auto_checks_out_remote_partial_branches() {
 		"expected partial branches to __not be__ checked out locally, to be able to test later that they will be."
 	);
 
-	await gitStackedRebase(RemoteAlice.initialBranch, {
+	await gitStackedRebase({
+		initialBranch: RemoteAlice.initialBranch,
 		gitDir: LocalBob.repo.workdir(),
 		[editor__internal]: () => void 0 /** no edit */,
 	});
@@ -90,7 +91,8 @@ async function give_chosen_name_to_local_branch() {
 		"expected partial branches to __not be__ checked out locally, to be able to test later that they will be."
 	);
 
-	await gitStackedRebase(RemoteAlice.initialBranch, {
+	await gitStackedRebase({
+		initialBranch: RemoteAlice.initialBranch,
 		gitDir: LocalBob.repo.workdir(),
 		[editor__internal]: ({filePath}) => {
 			const branchNameOf2ndBranch: string = RemoteAlice.newPartialBranches[1][0];

--- a/test/experiment.spec.ts
+++ b/test/experiment.spec.ts
@@ -13,7 +13,6 @@ import { editor__internal } from "../internal";
 
 export async function testCase(): Promise<void> {
 	const {
-		initialBranch, //
 		common,
 		commitsInLatest,
 		read,
@@ -28,7 +27,7 @@ export async function testCase(): Promise<void> {
 
 	const nthCommit2ndRebase = 5;
 
-	await gitStackedRebase(initialBranch, {
+	await gitStackedRebase({
 		...common,
 		[editor__internal]: async ({ filePath }) => {
 			humanOpChangeCommandOfNthCommitInto("edit", {
@@ -69,7 +68,7 @@ export async function testCase(): Promise<void> {
 	console.log("attempting early 3rd rebase to --apply");
 	read();
 
-	await gitStackedRebase(initialBranch, {
+	await gitStackedRebase({
 		...common,
 		apply: true,
 	});

--- a/test/non-first-rebase-has-initial-branch-cached.spec.ts
+++ b/test/non-first-rebase-has-initial-branch-cached.spec.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env ts-node-dev
+
+import fs from "fs";
+import path from "path";
+import assert from "assert";
+
+import { gitStackedRebase } from "../git-stacked-rebase";
+
+import { setupRepo } from "./util/setupRepo";
+import { isMarkedThatNeedsToApply } from "../apply";
+import { filenames } from "../filenames";
+import { askQuestion__internal, editor__internal, noEditor } from "../internal";
+import { humanOpChangeCommandOfNthCommitInto } from "../humanOp";
+import { Questions, question } from "../util/createQuestion";
+
+export async function nonFirstRebaseHasInitialBranchCached_TC() {
+	await scenario1();
+}
+
+async function scenario1() {
+	const { common, repo, commitsInLatest } = await setupRepo();
+
+	const initialBranch = "master" as const;
+
+	await gitStackedRebase({
+		...common,
+		initialBranch,
+		apply: false,
+		autoApplyIfNeeded: false,
+		[editor__internal]: ({ filePath }) => {
+			/**
+			 * force an apply to be needed, so that a second rebase is meaningful
+			 */
+			humanOpChangeCommandOfNthCommitInto("drop", {
+				filePath, //
+				commitSHA: commitsInLatest[2],
+			});
+		},
+	});
+
+	// BEGIN COPY_PASTE
+	// TODO take from `gitStackedRebase`:
+	const dotGitDirPath: string = repo.path();
+	const pathToStackedRebaseDirInsideDotGit: string = path.join(dotGitDirPath, "stacked-rebase");
+	assert.deepStrictEqual(
+		isMarkedThatNeedsToApply(pathToStackedRebaseDirInsideDotGit), //
+		true,
+		`expected a "needs-to-apply" mark to be set.`
+	);
+	// END COPY_PASTE
+
+	const pathToCache: string = path.join(pathToStackedRebaseDirInsideDotGit, filenames.initialBranch);
+	const isCached: boolean = fs.existsSync(pathToCache);
+	assert.deepStrictEqual(isCached, true, `expected initial branch to be cached after 1st run.`);
+
+	const cachedValue: string = fs.readFileSync(pathToCache, { encoding: "utf-8" });
+	assert.deepStrictEqual(
+		cachedValue,
+		initialBranch,
+		`expected the correct value to be cached ("${initialBranch}"), but found "${cachedValue}".`
+	);
+
+	console.log("performing 2nd rebase, expecting it to re-use the cached value of the initialBranch successfully.");
+
+	await gitStackedRebase({
+		...common,
+		/**
+		 * force unset initial branch
+		 */
+		initialBranch: undefined,
+		...noEditor,
+		[askQuestion__internal]: (q, ...rest) => {
+			if (q === Questions.need_to_apply_before_continuing) return "y";
+			return question(q, ...rest);
+		},
+	});
+}
+
+if (!module.parent) {
+	nonFirstRebaseHasInitialBranchCached_TC();
+}

--- a/test/parse-argv-resolve-options.spec.ts
+++ b/test/parse-argv-resolve-options.spec.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env ts-node-dev
+
+import fs from "fs";
+import path from "path";
+import os from "os";
+import assert from "assert";
+
+import Git from "nodegit";
+
+import {
+	ResolvedGitStackedRebaseOptions,
+	getDefaultResolvedOptions,
+	parseArgs,
+	parseArgv,
+	resolveOptions,
+} from "../git-stacked-rebase";
+
+import { rmdirSyncR } from "../util/fs";
+
+export async function parseArgvResolveOptions_TC() {
+	for (const testData of simpleTests) {
+		console.log({ testData });
+		await runSimpleTest(...testData);
+	}
+}
+
+type SimpleTestInput = [
+	specifiedOptions: Parameters<typeof parseArgv | typeof parseArgs>[0],
+	expectedOptions: Partial<ResolvedGitStackedRebaseOptions>
+];
+
+/**
+ * TODO:
+ * - [ ] custom setup, i.e. a function w/ context that's run before parsing the options, to e.g. modify the config
+ * - [ ] a way to handle Termination's, throw's in general
+ * - [ ] multiple rebases one after another, to e.g. test that initialBranch is not needed for 2nd invocation
+ *
+ * prolly better to have separate file for more advanced tests, & keep this one simple
+ */
+const simpleTests: SimpleTestInput[] = [
+	/** ensure defaults produce the same defaults: */
+	[["origin/master"], {}],
+	["origin/master", {}],
+
+	["custom-branch", { initialBranch: "custom-branch" }],
+
+	["origin/master -a", { apply: true }],
+	["origin/master --apply", { apply: true }],
+
+	["origin/master -p -f", { push: true, forcePush: true }],
+	["origin/master --push --force", { push: true, forcePush: true }],
+
+	["origin/master --continue", { continue: true }],
+
+	["origin/master", { autoSquash: false }],
+	["origin/master --autosquash", { autoSquash: true }],
+	["origin/master --autosquash --no-autosquash", { autoSquash: false }],
+	["origin/master --autosquash --no-autosquash --autosquash", { autoSquash: true }],
+	["origin/master --autosquash --no-autosquash --autosquash --no-autosquash", { autoSquash: false }],
+
+	["origin/master -s -x ls", { branchSequencer: true, branchSequencerExec: "ls" }],
+	["origin/master --bs -x ls", { branchSequencer: true, branchSequencerExec: "ls" }],
+	[
+		/** TODO E2E: test if paths to custom scripts work & in general if works as expected */
+		"origin/master --branch-sequencer --exec ./custom-script.sh",
+		{ branchSequencer: true, branchSequencerExec: "./custom-script.sh" },
+	],
+];
+
+async function runSimpleTest(specifiedOptions: SimpleTestInput[0], expectedOptions: SimpleTestInput[1]) {
+	const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "argv-options-test"));
+	const tmpfile = path.join(tmpdir, ".git-config");
+	const tmpGitConfig: Git.Config = await Git.Config.openOndisk(tmpfile);
+
+	const parsedArgv = typeof specifiedOptions === "string" ? parseArgs(specifiedOptions) : parseArgv(specifiedOptions);
+	console.log({ parsedArgv });
+
+	const resolvedOptions: ResolvedGitStackedRebaseOptions = await resolveOptions(parsedArgv, {
+		config: tmpGitConfig, //
+		dotGitDirPath: path.join(tmpdir, ".git"),
+	});
+
+	const fullExpectedOptions: ResolvedGitStackedRebaseOptions = { ...getDefaultResolvedOptions(), ...expectedOptions };
+	assert.deepStrictEqual(resolvedOptions, fullExpectedOptions);
+
+	// cleanup
+	rmdirSyncR(tmpdir);
+}
+
+if (!module.parent) {
+	parseArgvResolveOptions_TC();
+}

--- a/test/run.ts
+++ b/test/run.ts
@@ -5,6 +5,9 @@ import reducePathTC from "../git-reconcile-rewritten-list/reducePath.spec";
 import { parseNewGoodCommandsSpec } from "../parse-todo-of-stacked-rebase/parseNewGoodCommands.spec";
 import autoCheckoutRemotePartialBranchesTC from "./auto-checkout-remote-partial-branches.spec";
 import { applyTC } from "./apply.spec";
+import { argparse_TC } from "../argparse/argparse.spec";
+import { parseArgvResolveOptions_TC } from "./parse-argv-resolve-options.spec";
+import { nonFirstRebaseHasInitialBranchCached_TC } from "./non-first-rebase-has-initial-branch-cached.spec";
 
 import { sequentialResolve } from "../util/sequentialResolve";
 import { cleanupTmpRepos } from "./util/tmpdir";
@@ -26,6 +29,9 @@ function main() {
 		parseNewGoodCommandsSpec,
 		autoCheckoutRemotePartialBranchesTC,
 		applyTC,
+		async () => argparse_TC(),
+		parseArgvResolveOptions_TC,
+		nonFirstRebaseHasInitialBranchCached_TC,
 	])
 		.then(cleanupTmpRepos)
 		.then(() => {

--- a/test/run.ts
+++ b/test/run.ts
@@ -11,6 +11,14 @@ import { cleanupTmpRepos } from "./util/tmpdir";
 
 main();
 function main() {
+	process.on("uncaughtException", (e) => {
+		printErrorAndExit(e);
+	});
+
+	process.on("unhandledRejection", (e) => {
+		printErrorAndExit(e);
+	});
+
 	// TODO Promise.all
 	sequentialResolve([
 		testCase, //
@@ -24,8 +32,15 @@ function main() {
 			process.stdout.write("\nsuccess\n\n");
 			process.exit(0);
 		})
-		.catch((e) => {
-			process.stderr.write("\nfailure: " + e + "\n\n");
-			process.exit(1);
-		});
+		.catch(printErrorAndExit);
+}
+
+function printErrorAndExit(e: unknown) {
+	console.error(e);
+
+	console.log("\nfull trace:");
+	console.trace(e);
+
+	process.stdout.write("\nfailure\n\n");
+	process.exit(1);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,7 +36,11 @@
 	},
 	"exclude": [
 		"node_modules", //
-		"dist"
+		"dist",
+		/**
+		 * ignore test, because of annoying and incorrect error: TS4058
+		 */
+		"test"
 	],
 	"include": [
 		//

--- a/util/error.ts
+++ b/util/error.ts
@@ -1,1 +1,5 @@
-export class Termination extends Error {}
+export class Termination extends Error {
+	constructor(public message: string, public exitCode: number = 1) {
+		super(message);
+	}
+}

--- a/util/fs.ts
+++ b/util/fs.ts
@@ -1,3 +1,6 @@
 import fs from "fs";
 
 export const isDirEmptySync = (dirPath: fs.PathLike): boolean => fs.readdirSync(dirPath).length === 0;
+
+/** node mantainers are a-holes for this breaking change */
+export const rmdirSyncR = (dir: fs.PathLike) => fs.rmdirSync(dir, { recursive: true, ...{ force: true } });

--- a/util/removeUndefinedProperties.ts
+++ b/util/removeUndefinedProperties.ts
@@ -1,13 +1,16 @@
-export function removeUndefinedProperties<T, K extends keyof Partial<T>>(
-	object: Partial<T> //
-): Partial<T> {
-	return (
-		Object.keys(object).forEach(
-			(k) =>
-				k in object && //
-				object[k as K] === undefined &&
-				delete object[k as K]
-		),
-		object
-	);
+export function removeUndefinedProperties<T, U extends Partial<T>>(object: U): T {
+	for (const key in object) {
+		if (object[key] === undefined) {
+			delete object[key];
+		}
+	}
+
+	return object as unknown as T;
+	/**
+	 * TODO TS - we're not doing what we're saying we're doing here.
+	 *
+	 * we're simply deleting undefined properties,
+	 * but in the type system, we're saying that "we are adding legit values to properties who were undefined",
+	 * which is obviously incorrect.
+	 */
 }


### PR DESCRIPTION
BREAKING CHANGE: completely overhaul arg parsing & allow invoking CLI w/o initialBranch

...as long as the initialBranch was already provided
in some previous invocation of stacked-rebase, thus cached.
sometime later, we could have a config for the default initial branch..

- create generic utils for argv parsing (separate package soon?)
- introduce multiple tests, which caught lots of (mostly new) bugs!
- tidy up code at start of gitStackedRebase, which now makes great sense & looks nice
  - same in other places
- clear up mental model of "parsing options" - it's "resolve" instead of "parse"

- move initialBranch parsing into resolveOptions
  - don't want out of sync `resolvedOptions.initialBranch` vs `nameOfInitialBranch`

- get rid of "intial branch is optional for some args" -- non issue
  - because e.g. for --continue to have any meaning, you'd have to have already
    started a stacked rebase & thus would have the initial branch cached.
